### PR TITLE
[thermalmanager_dbus_if] Add names for thermal status values (JB#12048)

### DIFF
--- a/modules/thermalmanager_dbus_if.c
+++ b/modules/thermalmanager_dbus_if.c
@@ -29,4 +29,15 @@ const char thermalmanager_interface[]         = "com.nokia.thermalmanager";
 const char thermalmanager_path[]              = "/com/nokia/thermalmanager";
 
 const char thermalmanager_state_change_ind[]  = "thermal_state_change_ind";
-const char thermalmanager_get_thermal_state[] = "get_thermal_state";
+
+const char thermalmanager_get_thermal_state[]            = "get_thermal_state";
+const char thermalmanager_estimate_surface_temperature[] = "estimate_surface_temperature";
+const char thermalmanager_core_temperature[]             = "core_temperature";
+const char thermalmanager_battery_temperature[]          = "battery_temperature";
+const char thermalmanager_sensor_temperature[]           = "sensor_temperature";
+
+const char thermalmanager_thermal_status_low[]     = "low-temp-warning";
+const char thermalmanager_thermal_status_normal[]  = "normal";
+const char thermalmanager_thermal_status_warning[] = "warning";
+const char thermalmanager_thermal_status_alert[]   = "alert";
+const char thermalmanager_thermal_status_fatal[]   = "fatal";

--- a/modules/thermalmanager_dbus_if.h
+++ b/modules/thermalmanager_dbus_if.h
@@ -28,7 +28,21 @@ extern const char thermalmanager_service[];
 extern const char thermalmanager_interface[];
 extern const char thermalmanager_path[];
 
+// Signals
 extern const char thermalmanager_state_change_ind[];
+
+// Methods
 extern const char thermalmanager_get_thermal_state[];
+extern const char thermalmanager_estimate_surface_temperature[];
+extern const char thermalmanager_core_temperature[];
+extern const char thermalmanager_battery_temperature[];
+extern const char thermalmanager_sensor_temperature[];
+
+// Possible values for the status
+extern const char thermalmanager_thermal_status_low[];
+extern const char thermalmanager_thermal_status_normal[];
+extern const char thermalmanager_thermal_status_warning[];
+extern const char thermalmanager_thermal_status_alert[];
+extern const char thermalmanager_thermal_status_fatal[];
 
 #endif


### PR DESCRIPTION
These strings are right now hardcoded inside `dsme` and the to-be-discontinued `qmsystem2`. Instead, define it once here and use these values from both `dsme` and `lipstick` (which is where the remaining parts of `qmsystem2` related to thermal stuff go).